### PR TITLE
Fix Issue 221 - Don't continue looping until 3 responses received

### DIFF
--- a/lib/steam/servers/SourceServer.php
+++ b/lib/steam/servers/SourceServer.php
@@ -159,7 +159,7 @@ class SourceServer extends GameServer {
             }
 
             $response[] = $responsePacket->getResponse();
-        } while(sizeof($response) < 3 || strlen($responsePacket->getResponse()) > 0);
+        } while(strlen($responsePacket->getResponse()) > 0);
 
         return trim(join('', $response));
     }


### PR DESCRIPTION
With the old code, the "read response" loop would _continue_ if **either** of these conditions were met:
- Fewer than 3 responses had been received
- The most recently received response was not empty

So, the loop would only stop when _both_ conditions were false:
- 3+ responses had been received, AND
- The most recently received response was empty

For responses that returned empty. The loop would run twice and timeout on its second run (because there were no more packet to receive).

With this update, the "read response" loop will continue until it receives a response with an empty body (regardless of how many packets end up being received). Because the RCONTerminator packet it being sent, a response with an empty body will always be sent at the end.
